### PR TITLE
Fix: Mistook APIView with ViewSet

### DIFF
--- a/src/users/api/v1/urls.py
+++ b/src/users/api/v1/urls.py
@@ -1,10 +1,10 @@
 from django.urls import path
 
-from .viewsets import RegisterView,LoginView,UserView,LogoutView
+# from .viewsets import RegisterView,LoginView,UserView,LogoutView
 
 urlpatterns = [
-    path('register/', RegisterView.as_view()),
-    path('login/', LoginView.as_view()),
-    path('user/', UserView.as_view()),
-    path('logout/', LogoutView.as_view())
+    # path('register/', RegisterView.as_view()),
+    # path('login/', LoginView.as_view()),
+    # path('user/', UserView.as_view()),
+    # path('logout/', LogoutView.as_view())
 ]

--- a/src/users/api/v1/viewsets.py
+++ b/src/users/api/v1/viewsets.py
@@ -9,38 +9,80 @@ import jwt, datetime
 from django.utils import timezone
 
 
-class RegisterView(APIView):
-    """
-    View for user registration.
+# class RegisterView(APIView):
+#     """
+#     View for user registration.
 
-    This view handles the user registration process. It receives a POST request
-    with the user's username, email and password, creates a new user instance
-    with the provided data, and saves it to the database. It then returns a
-    response indicating that the user has been successfully registered.
+#     This view handles the user registration process. It receives a POST request
+#     with the user's username, email and password, creates a new user instance
+#     with the provided data, and saves it to the database. It then returns a
+#     response indicating that the user has been successfully registered.
+#     """
+
+#     allowed_methods = ['POST']
+
+#     def post(self, request):
+#         serializer = UserSerializer(data=request.data)
+#         serializer.is_valid(raise_exception=True)
+#         serializer.save()
+#         return Response(serializer.data)
+    
+class RegisterViewSet(viewsets.ViewSet):
+    """
+    API endpoint that allows users to be registered.
     """
 
-    def post(self, request):
+    def create(self, request):
         serializer = UserSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(serializer.data)
     
-class RegisterViewSet(viewsets.ModelViewSet):
-    """
-    API endpoint that allows users to be registered.
-    """
-    serializer_class = UserSerializer
+# class LoginView(APIView):
+#     """
+#     View for user login.
 
-class LoginView(APIView):
-    """
-    View for user login.
+#     This view handles the user login process. It receives a POST request
+#     with the user's username and password, validates the credentials,
+#     and returns a response containing a JWT token if the credentials are valid.
+#     """
 
-    This view handles the user login process. It receives a POST request
-    with the user's username and password, validates the credentials,
-    and returns a response containing a JWT token if the credentials are valid.
+#     allowed_methods = ['POST']
+
+#     def post(self, request):
+#         email = request.data.get('email')
+#         password = request.data.get('password')
+
+#         user = User.objects.filter(email=email).first()
+        
+#         if user is None:
+#             return Response({'error': 'Invalid email'}, status=400)        
+        
+#         if not user.check_password(password):
+#             return Response({'error': 'Invalid password'}, status=400)
+        
+#         payload = {
+#             'id': user.id,
+#             'exp': timezone.now() + datetime.timedelta(minutes=60),
+#             'iat': timezone.now()
+#         }
+        
+#         token = jwt.encode(payload, 'secret', algorithm='HS256')
+        
+#         response = Response()
+        
+#         response.set_cookie(key='jwt', value=token)
+#         response.data = {
+#             'token': token
+#         }
+#         return response
+    
+class LoginViewSet(viewsets.ViewSet):
+    """
+    API endpoint that allows users to be logged in.
     """
 
-    def post(self, request):
+    def create(self, request):
         email = request.data.get('email')
         password = request.data.get('password')
 
@@ -67,20 +109,42 @@ class LoginView(APIView):
             'token': token
         }
         return response
+
+
     
-class LoginViewSet(viewsets.ModelViewSet):
+    
+# class UserView(APIView):
+#     """
+#     View for user.
+
+#     This view returns the details of the currently logged-in user.
+#     """
+    
+#     allowed_methods = ['GET']
+    
+#     def get(self, request):
+#         token = request.COOKIES.get('jwt')
+        
+#         if not token:
+#             return Response({'error': 'Not authenticated'}, status=400)
+        
+#         try:
+#             payload = jwt.decode(token, 'secret', algorithms=['HS256'])
+#         except jwt.ExpiredSignatureError:
+#             return Response({'error': 'Token expired'}, status=400)
+        
+#         user = User.objects.filter(id=payload['id']).first()
+#         serializer = UserSerializer(user)
+        
+#         return Response(serializer.data)
+
+class UserViewSet(viewsets.ViewSet):
     """
-    API endpoint that allows users to be logged in.
+    API endpoint that allows users to be viewed.
     """
     serializer_class = UserSerializer
     
-class UserView(APIView):
-    """
-    View for user.
-
-    This view returns the details of the currently logged-in user.
-    """
-    def get(self, request):
+    def list(self, request):
         token = request.COOKIES.get('jwt')
         
         if not token:
@@ -96,24 +160,28 @@ class UserView(APIView):
         
         return Response(serializer.data)
 
-class UserViewSet(viewsets.ModelViewSet):
+# class LogoutView(APIView):
+    
+#     allowed_methods = ['POST']
+    
+#     def post(self, request):
+#         response = Response()
+#         response.delete_cookie('jwt')
+#         response.data = {
+#             'message': 'success'
+#         }
+#         return response
+    
+class LogoutViewSet(viewsets.ViewSet):
     """
-    API endpoint that allows users to be viewed.
+    API endpoint that allows users to be logged out.
     """
-    serializer_class = UserSerializer
-
-class LogoutView(APIView):
-    def post(self, request):
+    
+    def create(self, request):
         response = Response()
         response.delete_cookie('jwt')
         response.data = {
             'message': 'success'
         }
         return response
-    
-class LogoutViewSet(viewsets.ModelViewSet):
-    """
-    API endpoint that allows users to be logged out.
-    """
-    serializer_class = UserSerializer
 


### PR DESCRIPTION
- I didn't understand correctly how to use an APIView and a ViewSet. I thought that the two things are related and both needed to be implemented at the same time.
- Now I understand that the APIView is a single point url, that is meant to be mapped inside urls.py while ViewSet include multiple crud operations and are meant to be used with routers.
- Till this point the api worked because the APIView's urls were added first (before the router's urls), so when you went to localhost/api/v1/register you received the APIView not the router ViewSet. At the same time the links were present in api root because I included them in the router.
- I made the changes that I believe will fix my confustion, for now, I just commented on the code that needs to be deleted before I receive a green light for my changes.